### PR TITLE
Upgrade to purescript v0.12

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -12,7 +12,8 @@
     "output"
   ],
   "dependencies": {
-    "purescript-undefinable": "git://github.com/athanclark/purescript-undefinable.git#c0206e55574aa6104bb49b100a12af8529fa3184",
+    "purescript-prelude": "^4.1.0",
+    "purescript-undefinable": "^4.0.0",
     "purescript-effect": "^2.0.0"
   },
   "devDependencies": {

--- a/bower.json
+++ b/bower.json
@@ -12,12 +12,11 @@
     "output"
   ],
   "dependencies": {
-    "purescript-prelude": "^3.1.0",
-    "purescript-console": "^3.0.0",
-    "purescript-undefinable": "^3.0.0"
+    "purescript-prelude": "^4.1.0",
+    "purescript-undefinable": "git://github.com/athanclark/purescript-undefinable.git#c0206e55574aa6104bb49b100a12af8529fa3184"
   },
   "devDependencies": {
-    "purescript-psci-support": "^3.0.0",
-    "purescript-spec": "^1.0.0"
+    "purescript-psci-support": "^4.0.0",
+    "purescript-spec": "^3.1.0"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -12,8 +12,8 @@
     "output"
   ],
   "dependencies": {
-    "purescript-prelude": "^4.1.0",
-    "purescript-undefinable": "git://github.com/athanclark/purescript-undefinable.git#c0206e55574aa6104bb49b100a12af8529fa3184"
+    "purescript-undefinable": "git://github.com/athanclark/purescript-undefinable.git#c0206e55574aa6104bb49b100a12af8529fa3184",
+    "purescript-effect": "^2.0.0"
   },
   "devDependencies": {
     "purescript-psci-support": "^4.0.0",

--- a/bower.json
+++ b/bower.json
@@ -13,8 +13,8 @@
   ],
   "dependencies": {
     "purescript-prelude": "^4.1.0",
-    "purescript-undefinable": "^4.0.0",
-    "purescript-effect": "^2.0.0"
+    "purescript-effect": "^2.0.0",
+    "purescript-foreign": "^5.0.0"
   },
   "devDependencies": {
     "purescript-psci-support": "^4.0.0",

--- a/src/Data/Iterable.js
+++ b/src/Data/Iterable.js
@@ -1,11 +1,11 @@
 'use strict';
 
-exports.iterator = function() {
-  return function(iterable) {
-    return iterable[Symbol.iterator]();
-  };
+exports.unsafeIterator = function unsafeIterator(iterable) {
+  return iterable[Symbol.iterator]();
 };
 
-exports.next = function(iterator) {
-  return iterator.next();
+exports.next = function next(iterator) {
+  return function next_() {
+    return iterator.next();
+  };
 };

--- a/src/Data/Iterable.js
+++ b/src/Data/Iterable.js
@@ -4,8 +4,6 @@ exports.unsafeIterator = function unsafeIterator(iterable) {
   return iterable[Symbol.iterator]();
 };
 
-exports.next = function next(iterator) {
-  return function next_() {
-    return iterator.next();
-  };
+exports.nextImpl = function nextImpl(iterator) {
+  return iterator.next();
 };

--- a/src/Data/Iterable.js
+++ b/src/Data/Iterable.js
@@ -3,7 +3,7 @@
 exports.iterator = function() {
   return function(iterable) {
     return iterable[Symbol.iterator]();
-  }
+  };
 };
 
 exports.next = function(iterator) {

--- a/src/Data/Iterable.purs
+++ b/src/Data/Iterable.purs
@@ -1,11 +1,14 @@
-module Data.Iterable where
+module Data.Iterable
+  ( class Iterable, iterator, unsafeIterator, Iterator, next, traverse_, toArray
+  ) where
 
-import Prelude (Unit, (<$), unit, (>>=), pure, void, bind, discard)
-import Data.Maybe (maybe)
-import Data.Undefinable (Undefinable, toMaybe)
+import Prelude (Unit, (<$), unit, (>>=), pure, void, bind, discard, (<$>), otherwise)
+import Data.Maybe (Maybe (..), maybe)
 import Data.Array (snoc) as Array
 import Control.Monad.Rec.Class (tailRecM, Step (..))
+import Foreign (Foreign, unsafeFromForeign)
 import Effect (Effect)
+import Effect.Uncurried (EffectFn1, runEffectFn1)
 import Effect.Ref (new, modify, read) as Ref
 
 -- | The Iterable class corresponds to the Iterable interface in JS.
@@ -23,15 +26,22 @@ foreign import unsafeIterator :: forall iterable value. iterable -> Iterator val
 -- | Corresponds to an `Iterator` object in JS.
 foreign import data Iterator :: Type -> Type
 
--- | `next()` is an effectful function, treating a `Iterator value` as a stateful reference.
-foreign import next :: forall value. Iterator value -> Effect { value :: Undefinable value, done :: Boolean }
+foreign import nextImpl :: forall value. EffectFn1 (Iterator value) { value :: Foreign, done :: Boolean }
+
+-- | `next()` is an effectful function, treating a `Iterator value` similarly to a `Ref`.
+next :: forall value. Iterator value -> Effect (Maybe value)
+next i = toMaybe <$> runEffectFn1 nextImpl i
+  where
+    toMaybe {done,value}
+      | done = Nothing
+      | otherwise = Just (unsafeFromForeign value)
 
 -- | Consumes all values in the `Iterator`.
 traverse_ :: forall value. (value -> Effect Unit) -> Iterator value -> Effect Unit
 traverse_ f i = tailRecM go unit
   where
     go :: Unit -> Effect (Step Unit Unit)
-    go _ = next i >>= \{value} -> maybe (pure (Done unit)) (\x -> Loop unit <$ f x) (toMaybe value)
+    go _ = next i >>= \mv -> maybe (pure (Done unit)) (\x -> Loop unit <$ f x) mv
 
 -- | Consumes all values in the `Iterator`, and turns it into an array.
 toArray :: forall value. Iterator value -> Effect (Array value)

--- a/src/Data/Iterable.purs
+++ b/src/Data/Iterable.purs
@@ -1,22 +1,22 @@
 module Data.Iterable where
 
 import Data.Undefinable (Undefinable)
+import Effect (Effect)
 
 -- | The Iterable class corresponds to the Iterable interface in JS.
--- | Instances should have a property with the Symbol.iterator as the key. The
--- | property should return a function that takes no arguments and returns an
--- | Iterator
-class Iterable iterable value | iterable -> value
+-- | Instances should have a canonical `Iterator` returned.
+class Iterable iterable value | iterable -> value where
+  -- | Returns the `Iterator` from an `Iterable`
+  iterator :: iterable -> Iterator value
+instance iterableArray ∷ Iterable (Array a) a where
+  iterator = unsafeIterator
 
--- | Returns the Iterator from an Iterable
-foreign import iterator
-  ∷ ∀ iterable value. Iterable iterable value ⇒ iterable → Iterator value
+-- | Assume the `iterable` value has a property with the `Symbol.iterator` as the key, which is a nullary function
+-- | returning the `Iterator`.
+foreign import unsafeIterator :: forall iterable value. iterable -> Iterator value
 
-foreign import data Iterator ∷ Type → Type
+-- | Corresponds to an `Iterator` object in JS.
+foreign import data Iterator :: Type -> Type
 
-foreign import next
-  ∷ ∀ value
-  . Iterator value
-  → { value ∷ Undefinable value, done ∷ Boolean }
-
-instance iterableArray ∷ Iterable (Array a) a
+-- | `next()` is an effectful function, treating a `Iterator value` as a stateful reference.
+foreign import next :: forall value. Iterator value -> Effect { value :: Undefinable value, done :: Boolean }

--- a/test/Data/Iterable.purs
+++ b/test/Data/Iterable.purs
@@ -47,3 +47,9 @@ main = run [consoleReporter] do
         g <- liftEffect (next it)
         g.done `shouldEqual` true
         (toMaybe g.value) `shouldEqual` Nothing
+
+      it "should be isomorphic to an array" do
+        let it' = [1,2,3,4]
+
+        xs <- liftEffect (toArray (iterator it'))
+        xs `shouldEqual` it'

--- a/test/Data/Iterable.purs
+++ b/test/Data/Iterable.purs
@@ -4,7 +4,6 @@ import Data.Iterable
 
 import Effect (Effect)
 import Effect.Class (liftEffect)
-import Data.Undefinable (toMaybe)
 import Data.Maybe (Maybe(..))
 import Prelude (Unit, discard, bind)
 import Test.Spec (describe, it)
@@ -21,32 +20,25 @@ main = run [consoleReporter] do
         let it = iterator [1, 1, 2, 3, 5, 8]
 
         a <- liftEffect (next it)
-        a.done `shouldEqual` false
-        (toMaybe a.value) `shouldEqual` (Just 1)
+        a `shouldEqual` (Just 1)
 
         b <- liftEffect (next it)
-        b.done `shouldEqual` false
-        (toMaybe b.value) `shouldEqual` (Just 1)
+        b `shouldEqual` (Just 1)
 
         c <- liftEffect (next it)
-        c.done `shouldEqual` false
-        (toMaybe c.value) `shouldEqual` (Just 2)
+        c `shouldEqual` (Just 2)
 
         d <- liftEffect (next it)
-        d.done `shouldEqual` false
-        (toMaybe d.value) `shouldEqual` (Just 3)
+        d `shouldEqual` (Just 3)
 
         e <- liftEffect (next it)
-        e.done `shouldEqual` false
-        (toMaybe e.value) `shouldEqual` (Just 5)
+        e `shouldEqual` (Just 5)
 
         f <- liftEffect (next it)
-        f.done `shouldEqual` false
-        (toMaybe f.value) `shouldEqual` (Just 8)
+        f `shouldEqual` (Just 8)
 
         g <- liftEffect (next it)
-        g.done `shouldEqual` true
-        (toMaybe g.value) `shouldEqual` Nothing
+        g `shouldEqual` Nothing
 
       it "should be isomorphic to an array" do
         let it' = [1,2,3,4]

--- a/test/Data/Iterable.purs
+++ b/test/Data/Iterable.purs
@@ -2,47 +2,48 @@ module Test.Data.Iterable where
 
 import Data.Iterable
 
-import Control.Monad.Eff (Eff)
+import Effect (Effect)
+import Effect.Class (liftEffect)
 import Data.Undefinable (toMaybe)
 import Data.Maybe (Maybe(..))
-import Prelude (Unit, discard)
+import Prelude (Unit, discard, bind)
 import Test.Spec (describe, it)
 import Test.Spec.Assertions (shouldEqual)
 import Test.Spec.Reporter.Console (consoleReporter)
-import Test.Spec.Runner (RunnerEffects, run)
+import Test.Spec.Runner (run)
 
 
-main ∷ Eff (RunnerEffects ()) Unit
+main ∷ Effect Unit
 main = run [consoleReporter] do
   describe "purescript-iterable" do
     describe "iterator" do
       it "should return an iterator that can be iterated" do
         let it = iterator [1, 1, 2, 3, 5, 8]
 
-        let a = next it
+        a <- liftEffect (next it)
         a.done `shouldEqual` false
         (toMaybe a.value) `shouldEqual` (Just 1)
 
-        let b = next it
+        b <- liftEffect (next it)
         b.done `shouldEqual` false
         (toMaybe b.value) `shouldEqual` (Just 1)
 
-        let c = next it
+        c <- liftEffect (next it)
         c.done `shouldEqual` false
         (toMaybe c.value) `shouldEqual` (Just 2)
 
-        let d = next it
+        d <- liftEffect (next it)
         d.done `shouldEqual` false
         (toMaybe d.value) `shouldEqual` (Just 3)
 
-        let e = next it
+        e <- liftEffect (next it)
         e.done `shouldEqual` false
         (toMaybe e.value) `shouldEqual` (Just 5)
 
-        let f = next it
+        f <- liftEffect (next it)
         f.done `shouldEqual` false
         (toMaybe f.value) `shouldEqual` (Just 8)
 
-        let g = next it
+        g <- liftEffect (next it)
         g.done `shouldEqual` true
         (toMaybe g.value) `shouldEqual` Nothing

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -1,9 +1,8 @@
 module Test.Main where
 
 import Prelude
-import Control.Monad.Eff (Eff)
-import Test.Spec.Runner (RunnerEffects)
+import Effect (Effect)
 import Test.Data.Iterable (main) as Test
 
-main ∷ Eff (RunnerEffects ()) Unit
+main ∷ Effect Unit
 main = Test.main


### PR DESCRIPTION
This just needed some updates to version constraints. I also took the liberty of slightly redesigning the API - `Iterator`s are now considered `Effect`ful, stateful references, and `next()` reflects this. I've also included `traverse_` and `toArray` utility functions, and updated the tests.

I've also set the purescript-undefinable constraint to ^4.0.0; I've got another PR over there waiting to get accepted.